### PR TITLE
add iso pain format XCT order type

### DIFF
--- a/lib/predefinedOrders/XCT.js
+++ b/lib/predefinedOrders/XCT.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = document => ({
+	version: 'h004',
+	orderDetails: { OrderType: 'XCT', OrderAttribute: 'OZHNN', StandardOrderParams: {} },
+	operation: 'upload',
+	document,
+});

--- a/lib/predefinedOrders/index.js
+++ b/lib/predefinedOrders/index.js
@@ -12,6 +12,7 @@ const CDS = require('./CDS');
 const CCT = require('./CCT');
 const CCS = require('./CCS');
 const XE3 = require('./XE3');
+const XCT = require('./XCT');
 
 const STA = require('./STA');
 const VMK = require('./VMK');
@@ -35,7 +36,7 @@ module.exports = {
 	CCT,
 	CCS,
 	XE3,
-
+	XCT,
 	STA,
 	VMK,
 	HAA,


### PR DESCRIPTION
We currently have CCT order type as it is  (DK version, pain.001.003.03), i just introduced XCT which is 
(original ISO, pain.001.001.03).

