### PR TITLE
README.md: Add Bank GPB International S.A. to supported bank list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The client is currently tested and verified to work with the following banks:
 * [Zürcher Kantonalbank](https://www.zkb.ch/en/lg/ew.html)
 * [Raiffeisen Schweiz](https://www.raiffeisen.ch/rch/de.html)
 * [BW Bank](https://www.bw-bank.de/de/home.html)
+* [Bank GPB International S.A.](https://gazprombank.lu/e-banking)
 
 
 ## Inspiration


### PR DESCRIPTION
I was able to test DKI, INI, HAA, HAC, HEV, HVD, STA, VMK, XG1 with Bank GPB International S.A. and all worked fine, so I think we're good to add it to the supported bank list.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>