### PR TITLE
Add XG1 order type and example

### DIFF
--- a/examples/send-xg1-order.js
+++ b/examples/send-xg1-order.js
@@ -1,0 +1,27 @@
+#! /usr/bin/env node
+
+'use strict';
+
+const ebics = require('../index');
+const fs = require('fs');
+
+const client = new ebics.Client({
+	url: 'https://ebics.server',
+	partnerId: '',
+	userId: '',
+	hostId: '',
+	passphrase: 'test', // keys-test will be decrypted with this passphrase
+	keyStorage: ebics.fsKeysStorage('./keys-test'),
+});
+
+// The bank keys must have been already saved
+const paymentFile = fs.readFileSync('mytestfile.xml').toString();
+
+client.send(ebics.Orders.XG1(paymentFile))
+	.then((resp) => {
+		console.log('Response for XG1 order %j', resp);
+	})
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	});

--- a/lib/predefinedOrders/XG1.js
+++ b/lib/predefinedOrders/XG1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = document => ({
+	version: 'h004',
+	orderDetails: { OrderType: 'XG1', OrderAttribute: 'OZHNN', StandardOrderParams: {} },
+	operation: 'upload',
+	document,
+});

--- a/lib/predefinedOrders/index.js
+++ b/lib/predefinedOrders/index.js
@@ -13,6 +13,7 @@ const CCT = require('./CCT');
 const CCS = require('./CCS');
 const XE3 = require('./XE3');
 const XCT = require('./XCT');
+const XG1 = require('./XG1');
 
 const STA = require('./STA');
 const VMK = require('./VMK');
@@ -42,6 +43,7 @@ module.exports = {
 	CCS,
 	XE3,
 	XCT,
+	XG1,
 
 	STA,
 	VMK,


### PR DESCRIPTION
XG1 order type is used for ISO XML 20022 CGI (Common Global Implementation) which should be a unified format that works within a country (irrespective of bank).

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>